### PR TITLE
Upgrade to v1.0.3

### DIFF
--- a/Scripts/Console.cs
+++ b/Scripts/Console.cs
@@ -24,6 +24,11 @@ namespace Hibzz.Console
 		public static bool IsTextboxFocused = false;
 
 		/// <summary>
+		/// A dictionary to store cache results and intermediary values that can be used in the next process
+		/// </summary>
+		public static Dictionary<string, Object> CacheDictionary = new Dictionary<string, Object>();
+
+		/// <summary>
 		/// Static class that adds a log to the singleton instance
 		/// </summary>
 		/// <param name="message"> the message to add </param>

--- a/Scripts/Prebuilt Commands/Clear.cs
+++ b/Scripts/Prebuilt Commands/Clear.cs
@@ -22,8 +22,8 @@ namespace Hibzz.Console
 			// if there are any arguments passed, check for matching subcommands
 			if(args.Length > 0)
 			{
-				// -o clears the cache dictionary
-				if(args[0] == "-o")
+				// -cd clears the cache dictionary
+				if(args[0] == "-cd")
 				{
 					Console.CacheDictionary.Clear();
 					return true;

--- a/Scripts/Prebuilt Commands/Clear.cs
+++ b/Scripts/Prebuilt Commands/Clear.cs
@@ -19,6 +19,22 @@ namespace Hibzz.Console
 
 		public override bool Process(string[] args)
 		{
+			// if there are any arguments passed, check for matching subcommands
+			if(args.Length > 0)
+			{
+				// -o clears the cache dictionary
+				if(args[0] == "-o")
+				{
+					Console.CacheDictionary.Clear();
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			}
+
+			// clear the console logs
 			Console.Clear();
 			return true;
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.console",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "displayName": "hibzz.console",
   "description": "A simple and flexible in-game console",
   "documentationUrl": "https://github.com/Hibzz-Games/unity.console/wiki/Documentation",


### PR DESCRIPTION
### Brief
Added a dictionary of objects used to store results as a cache to facilitate the communication between different commands. This dictionary can store objects of any type, but when requested from the dictionary cast it back to the type needed. The command `/clear -cd` clears the cache dictionary. 

### Example use cases
- The `/find` command finds a gameobject with the given name and stores it in the cache dictionary if found. The `/getcomponent` command then gets the requested component from the cached gameobject which in turn can be cached (or do whatever needs to be done).
- The `/load-prefab` command loads the given prefab to cache and the `/instantiate` command can use the cached object to instantiate the prefab at the preferred position.